### PR TITLE
wait for stripe js to load before trying to open

### DIFF
--- a/addon/services/stripe.js
+++ b/addon/services/stripe.js
@@ -47,9 +47,11 @@ export default Service.extend({
    * @public
    */
   open(component) {
-    let config = this._stripeConfig(component);
-    let stripeHandler = this._stripeHandler(component);
-    stripeHandler.open(config);
+    this._stripeScriptPromise.then(() => {
+      let config = this._stripeConfig(component);
+      let stripeHandler = this._stripeHandler(component);
+      stripeHandler.open(config);
+    });
   },
 
   /*
@@ -113,7 +115,7 @@ export default Service.extend({
             false,
             { id: 'ember-cli-stripe.action-callback', until: '1.1.0' }
           );
-          
+
           invokeAction(component, 'action', ...arguments);
         }
       },


### PR DESCRIPTION
This fixes issue #30 - This was caused by a race condition on loading the stripe library. This may have impacted people if they clicked the button fast enough on page load (very unlikely but possible).