### PR TITLE
adding fastboot support

### DIFF
--- a/addon/components/stripe-checkout.js
+++ b/addon/components/stripe-checkout.js
@@ -67,7 +67,7 @@ export default Component.extend({
     this.get('stripe').close(this);
   },
 
-  init() {
+  willInsertElement() {
     this._super(...arguments);
     this.get('stripe').registerComponent(this);
   },

--- a/addon/services/stripe.js
+++ b/addon/services/stripe.js
@@ -47,7 +47,7 @@ export default Service.extend({
    * @public
    */
   open(component) {
-    this._stripeScriptPromise.then(() => {
+    return this._stripeScriptPromise.then(() => {
       let config = this._stripeConfig(component);
       let stripeHandler = this._stripeHandler(component);
       stripeHandler.open(config);

--- a/addon/services/stripe.js
+++ b/addon/services/stripe.js
@@ -49,7 +49,7 @@ export default Service.extend({
   open(component) {
     return this._stripeScriptPromise.then(() => {
       let config = this._stripeConfig(component);
-      let stripeHandler = this._stripeHandler(component);
+      let stripeHandler = this._stripeHandler(component) || this._registerNewStripeHandler(component);
       stripeHandler.open(config);
     });
   },
@@ -60,7 +60,10 @@ export default Service.extend({
    */
   close(component) {
     let stripeHandler = this._stripeHandler(component);
-    stripeHandler.close();
+
+    if (stripeHandler) {
+      stripeHandler.close();
+    }
   },
 
   init() {
@@ -98,6 +101,10 @@ export default Service.extend({
     if ('handler' in this._alive[componentGuid]) {
       return this._alive[componentGuid]['handler'];
     }
+  },
+
+  _registerNewStripeHandler(component) {
+    let componentGuid = guidFor(component);
 
     let stripeConfig = this._stripeConfig(component);
     if (!('key' in stripeConfig)) {

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -24,6 +24,7 @@ moduleFor('service:stripe', 'Unit | Service | stripe', {
     service = StripeService.create({
       stripeConfig: stripe,
       _scriptLoading: true,
+      _stripeScriptPromise: new Ember.RSVP.Promise((resolve) => resolve()),
     });
   },
 
@@ -74,22 +75,22 @@ test('open() opens Stripe Checkout with correct config options', function(assert
     component: stripeComponent,
   };
 
-  service.open(stripeComponent);
+  service.open(stripeComponent).then(() => {
+    let handlerOptions = {
+      key: config.stripe.key,
+      token: sinon.match.func,
+      opened: sinon.match.func,
+      closed: sinon.match.func,
+    };
+    sinon.assert.calledWith(configureCheckoutStub, sinon.match.object);
+    sinon.assert.calledWith(configureCheckoutStub, sinon.match(handlerOptions));
 
-  let handlerOptions = {
-    key: config.stripe.key,
-    token: sinon.match.func,
-    opened: sinon.match.func,
-    closed: sinon.match.func,
-  };
-  sinon.assert.calledWith(configureCheckoutStub, sinon.match.object);
-  sinon.assert.calledWith(configureCheckoutStub, sinon.match(handlerOptions));
-
-  const stripeOptions = {
-    key: config.stripe.key,
-    name: stripeComponent.get('name'),
-  };
-  assert.ok(openCheckoutSpy.calledWith(stripeOptions), 'opens Stripe checkout with correct config options');
+    const stripeOptions = {
+      key: config.stripe.key,
+      name: stripeComponent.get('name'),
+    };
+    assert.ok(openCheckoutSpy.calledWith(stripeOptions), 'opens Stripe checkout with correct config options');
+  });
 });
 
 test('close() closes Stripe Checkout', function(assert) {

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -62,7 +62,8 @@ test('unregisterComponent() unregisters the component', function(assert) {
 test('open() opens Stripe Checkout with correct config options', function(assert) {
   window.StripeCheckout = {
     configure() {},
-    open() {}
+    open() {},
+    close() {},
   };
   const openCheckoutSpy = this.spy();
   const configureCheckoutStub = this.stub(window.StripeCheckout, 'configure');
@@ -96,7 +97,8 @@ test('open() opens Stripe Checkout with correct config options', function(assert
 test('close() closes Stripe Checkout', function(assert) {
   window.StripeCheckout = {
     configure() {},
-    open() {}
+    open() {},
+    close() {},
   };
   const closeCheckoutSpy = this.spy();
   const configureCheckoutStub = this.stub(window.StripeCheckout, 'configure');
@@ -107,10 +109,18 @@ test('close() closes Stripe Checkout', function(assert) {
   const componentGuid = guidFor(stripeComponent);
   service._alive[componentGuid] = {
     component: stripeComponent,
+    handler: configureCheckoutStub(),
   };
-
 
   service.close(stripeComponent);
 
   assert.ok(closeCheckoutSpy.calledOnce, 'closes Stripe checkout when it is opened');
+});
+
+test('close() does nothing if StripeCheckout is not yet loaded', function(assert) {
+  const componentGuid = guidFor(stripeComponent);
+  service._alive[componentGuid] = {
+    component: stripeComponent,
+  };
+  assert.equal(null, service.close(stripeComponent), 'does not attempt to access StripeCheckout when it is not defined');
 });


### PR DESCRIPTION
Fastboot dies if this runs on init as there is no document. This moves the script including to the first time a component is about to render which happens client side.