### PR TITLE
bump ember-invoke-action

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-invoke-action": "1.4.0"
+    "ember-invoke-action": "^1.5.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
deprecation related to ember-invoke-action should no longer appear.