### PR TITLE
Rename master to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 
 branches:
   only:
-    - master
+    - main
     # npm version tags
     - /^v\d+\.\d+\.\d+/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stripe checkout for Ember [![Build Status](https://travis-ci.org/smile-io/ember-cli-stripe.svg?branch=master)](http://travis-ci.org/smile-io/ember-cli-stripe)
+# Stripe checkout for Ember [![Build Status](https://travis-ci.org/smile-io/ember-cli-stripe.svg?branch=main)](http://travis-ci.org/smile-io/ember-cli-stripe)
 
 ![Preview](https://user-images.githubusercontent.com/160955/42161490-d734da26-7e03-11e8-97ca-761285ac2dff.png)
 


### PR DESCRIPTION
# Rename master to main

This pull request removes the master branch reference from the repository to be ready to rename `master` to `main`.