### PR TITLE
ACT-283 Address @babel/runtime security-vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "overrides": {
       "micromatch@3.1.10>braces": "3.0.3",
       "broccoli@3.5.2>ansi-html": "0.0.8",
-      "broccoli-middleware@2.1.1>ansi-html": "0.0.8"
+      "broccoli-middleware@2.1.1>ansi-html": "0.0.8",
+      "ember-cli-babel>@babel/runtime": "7.26.10"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   micromatch@3.1.10>braces: 3.0.3
   broccoli@3.5.2>ansi-html: 0.0.8
   broccoli-middleware@2.1.1>ansi-html: 0.0.8
+  ember-cli-babel>@babel/runtime: 7.26.10
 
 importers:
 
@@ -809,9 +810,6 @@ packages:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-
-  '@babel/runtime@7.12.18':
-    resolution: {integrity: sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==}
 
   '@babel/runtime@7.26.10':
     resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
@@ -7476,10 +7474,6 @@ snapshots:
       '@babel/types': 7.26.7
       esutils: 2.0.3
 
-  '@babel/runtime@7.12.18':
-    dependencies:
-      regenerator-runtime: 0.13.11
-
   '@babel/runtime@7.26.10':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -10105,7 +10099,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.26.7)
       '@babel/polyfill': 7.12.1
       '@babel/preset-env': 7.26.7(@babel/core@7.26.7)
-      '@babel/runtime': 7.12.18
+      '@babel/runtime': 7.26.10
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.26.7)
       babel-plugin-ember-data-packages-polyfill: 0.1.2
@@ -10140,7 +10134,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.26.7)
       '@babel/preset-env': 7.26.7(@babel/core@7.26.7)
-      '@babel/runtime': 7.12.18
+      '@babel/runtime': 7.26.10
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.26.7)
       babel-plugin-ember-data-packages-polyfill: 0.1.2


### PR DESCRIPTION
Fixes the following secutiry vulnerability:
https://github.com/smile-io/ember-cli-stripe/security/dependabot/141