### PR TITLE
Resolve underscore and @tootallnate/once vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
       "ajv@>=7.0.0-alpha.0 <8.18.0": "^8.18.0",
       "minimatch@<10.2.3": "^10.2.3",
       "serialize-javascript@<=7.0.2": "^7.0.3",
-      "rollup@>=4.0.0 <4.59.0": "^4.59.0"
+      "rollup@>=4.0.0 <4.59.0": "^4.59.0",
+      "underscore@<1.13.8": "^1.13.8",
+      "@tootallnate/once@<3.0.1": "^3.0.1"
     },
     "patchedDependencies": {
       "minimatch@10.2.4": "patches/minimatch@10.2.4.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,8 @@ overrides:
   minimatch@<10.2.3: ^10.2.3
   serialize-javascript@<=7.0.2: ^7.0.3
   rollup@>=4.0.0 <4.59.0: ^4.59.0
+  underscore@<1.13.8: ^1.13.8
+  '@tootallnate/once@<3.0.1': ^3.0.1
 
 patchedDependencies:
   minimatch@10.2.4:
@@ -180,7 +182,7 @@ importers:
         version: 2.10.0(webpack@5.105.2)
       ember-cli:
         specifier: ~6.1.0
-        version: 6.1.0(handlebars@4.7.8)(underscore@1.13.7)
+        version: 6.1.0(handlebars@4.7.8)(underscore@1.13.8)
       ember-cli-app-version:
         specifier: ^7.0.0
         version: 7.0.0(ember-source@6.2.0(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.105.2))
@@ -192,7 +194,7 @@ importers:
         version: 3.0.0
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.1.0(handlebars@4.7.8)(underscore@1.13.7))
+        version: 3.3.3(ember-cli@6.1.0(handlebars@4.7.8)(underscore@1.13.8))
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -1655,9 +1657,9 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
+  '@tootallnate/once@3.0.1':
+    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
+    engines: {node: '>= 10'}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -2694,7 +2696,7 @@ packages:
       toffee: ^0.3.6
       twig: ^1.15.2
       twing: ^5.0.2
-      underscore: ^1.11.0
+      underscore: ^1.13.8
       vash: ^0.13.0
       velocityjs: ^2.0.1
       walrus: ^0.10.1
@@ -6395,8 +6397,8 @@ packages:
   underscore.string@3.3.6:
     resolution: {integrity: sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==}
 
-  underscore@1.13.7:
-    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -8461,7 +8463,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tootallnate/once@1.1.2': {}
+  '@tootallnate/once@3.0.1': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -9071,7 +9073,7 @@ snapshots:
 
   backbone@1.6.1:
     dependencies:
-      underscore: 1.13.7
+      underscore: 1.13.8
 
   backburner.js@2.8.0: {}
 
@@ -9850,14 +9852,14 @@ snapshots:
       ora: 3.4.0
       through2: 3.0.2
 
-  consolidate@0.16.0(handlebars@4.7.8)(lodash@4.17.23)(mustache@4.2.0)(underscore@1.13.7):
+  consolidate@0.16.0(handlebars@4.7.8)(lodash@4.17.23)(mustache@4.2.0)(underscore@1.13.8):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
       handlebars: 4.7.8
       lodash: 4.17.23
       mustache: 4.2.0
-      underscore: 1.13.7
+      underscore: 1.13.8
 
   content-disposition@0.5.4:
     dependencies:
@@ -10220,10 +10222,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.3(ember-cli@6.1.0(handlebars@4.7.8)(underscore@1.13.7)):
+  ember-cli-dependency-checker@3.3.3(ember-cli@6.1.0(handlebars@4.7.8)(underscore@1.13.8)):
     dependencies:
       chalk: 2.4.2
-      ember-cli: 6.1.0(handlebars@4.7.8)(underscore@1.13.7)
+      ember-cli: 6.1.0(handlebars@4.7.8)(underscore@1.13.8)
       find-yarn-workspace-root: 2.0.0
       is-git-url: 1.0.0
       resolve: 1.22.10
@@ -10341,7 +10343,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli@6.1.0(handlebars@4.7.8)(underscore@1.13.7):
+  ember-cli@6.1.0(handlebars@4.7.8)(underscore@1.13.8):
     dependencies:
       '@pnpm/find-workspace-dir': 7.0.3
       babel-remove-types: 1.0.1
@@ -10420,7 +10422,7 @@ snapshots:
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
       temp: 0.9.4
-      testem: 3.16.0(handlebars@4.7.8)(underscore@1.13.7)
+      testem: 3.16.0(handlebars@4.7.8)(underscore@1.13.8)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       walk-sync: 3.0.0
@@ -11894,7 +11896,7 @@ snapshots:
 
   http-proxy-agent@4.0.1:
     dependencies:
-      '@tootallnate/once': 1.1.2
+      '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
       debug: 4.4.1
     transitivePeerDependencies:
@@ -14126,7 +14128,7 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  testem@3.16.0(handlebars@4.7.8)(underscore@1.13.7):
+  testem@3.16.0(handlebars@4.7.8)(underscore@1.13.8):
     dependencies:
       '@xmldom/xmldom': 0.8.10
       backbone: 1.6.1
@@ -14134,7 +14136,7 @@ snapshots:
       charm: 1.0.2
       commander: 2.20.3
       compression: 1.8.0
-      consolidate: 0.16.0(handlebars@4.7.8)(lodash@4.17.23)(mustache@4.2.0)(underscore@1.13.7)
+      consolidate: 0.16.0(handlebars@4.7.8)(lodash@4.17.23)(mustache@4.2.0)(underscore@1.13.8)
       execa: 1.0.0
       express: 4.21.2
       fireworm: 0.7.2
@@ -14397,7 +14399,7 @@ snapshots:
       sprintf-js: 1.1.3
       util-deprecate: 1.0.2
 
-  underscore@1.13.7: {}
+  underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Ticket
- [ACT-1479](https://linear.app/smile/issue/ACT-1479/fix-underscore-vulnerability-in-ember-cli-stripe)
- [ACT-1486](https://linear.app/smile/issue/ACT-1486/fix-tootallnateonce-vulnerability-in-ember-cli-stripe)

## Description

Resolves two security vulnerabilities via `pnpm.overrides` in the root `package.json`:

### CVE-2026-27601 — `underscore` (High)
- **Advisory**: https://github.com/smile-io/ember-cli-stripe/security/dependabot/173
- **Vulnerable**: `<1.13.8`
- **Fix**: Override to `^1.13.8`

### CVE-2026-3449 — `@tootallnate/once` (Low)
- **Advisory**: https://github.com/smile-io/ember-cli-stripe/security/dependabot/174
- **Vulnerable**: `<3.0.1`
- **Fix**: Override to `^3.0.1`

Both are transitive dependencies resolved via `pnpm.overrides`.

## Testing

`pnpm audit` output after fix — only an unrelated `tar` advisory (already tracked separately) remains; the `underscore` and `@tootallnate/once` vulnerabilities are no longer reported.

## Deployment dependencies

None
