### PR TITLE
Add default exports to utility modules for Vite compatibility

### DIFF
--- a/ember-cli-stripe/src/utils/configuration-options.js
+++ b/ember-cli-stripe/src/utils/configuration-options.js
@@ -121,3 +121,4 @@ const compactOptions = (options) => {
 };
 
 export { configurationOptions, compactOptions };
+export default { configurationOptions, compactOptions };

--- a/ember-cli-stripe/src/utils/load-script.js
+++ b/ember-cli-stripe/src/utils/load-script.js
@@ -61,3 +61,4 @@ if (macroCondition(isTesting())) {
 }
 
 export { loadScript };
+export default loadScript;


### PR DESCRIPTION
## Summary

- Add default exports to `utils/configuration-options.js` and `utils/load-script.js` to fix Vite/esbuild compatibility
- Existing named exports are preserved for backwards compatibility

## Context

We're migrating `smile-admin` from Embroider+Webpack to Embroider+Vite. The Embroider V2 addon `appReexports` plugin generates re-export proxies that use `export { default } from '...'` for every module registered in the app tree.

Under Webpack, this was silently tolerated even when the source module had no default export. However, Vite's dep optimizer (esbuild) is strict: it fails with `No matching export ... for import "default"` when the source module lacks a default export.

Two utility modules (`configuration-options` and `load-script`) only had named exports. This PR adds default exports to both, satisfying the re-export proxy contract without changing the public API.

## Test plan

- [ ] Verify `pnpm build` succeeds in the addon (confirmed locally)
- [ ] Verify `smile-admin` Vite build no longer errors on these modules
- [ ] Verify existing imports of named exports (`configurationOptions`, `compactOptions`, `loadScript`) continue to work