### PR TITLE
Fix @xmldom/xmldom and uuid vulnerabilities (ACT-1696)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,9 @@
       "path-to-regexp@<0.1.13": "^0.1.13",
       "path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0",
       "lodash@<=4.17.23": "^4.18.0",
-      "@xmldom/xmldom@<0.8.12": "^0.8.12",
-      "follow-redirects@<=1.15.11": "^1.16.0"
+      "@xmldom/xmldom@<0.8.13": "^0.8.13",
+      "follow-redirects@<=1.15.11": "^1.16.0",
+      "uuid@<14.0.0": "^14.0.0"
     },
     "patchedDependencies": {
       "minimatch@10.2.4": "patches/minimatch@10.2.4.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,9 @@ overrides:
   path-to-regexp@<0.1.13: ^0.1.13
   path-to-regexp@>=8.0.0 <8.4.0: ^8.4.0
   lodash@<=4.17.23: ^4.18.0
-  '@xmldom/xmldom@<0.8.12': ^0.8.12
+  '@xmldom/xmldom@<0.8.13': ^0.8.13
   follow-redirects@<=1.15.11: ^1.16.0
+  uuid@<14.0.0: ^14.0.0
 
 patchedDependencies:
   minimatch@10.2.4:
@@ -1854,8 +1855,8 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
@@ -6487,8 +6488,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache@2.4.0:
@@ -8740,7 +8741,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -12767,7 +12768,7 @@ snapshots:
       is-wsl: 2.2.0
       semver: 7.7.2
       shellwords: 0.1.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       which: 2.0.2
 
   node-releases@2.0.19: {}
@@ -14136,7 +14137,7 @@ snapshots:
 
   testem@3.16.0(handlebars@4.7.9)(underscore@1.13.8):
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       backbone: 1.6.1
       bluebird: 3.7.2
       charm: 1.0.2
@@ -14468,7 +14469,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache@2.4.0: {}
 


### PR DESCRIPTION
## Summary

Linear: [ACT-1696 — Fix @xmldom/xmldom and uuid vulnerabilities in ember-cli-stripe](https://linear.app/smile/issue/ACT-1696/fix-xmldomxmldom-and-uuid-vulnerabilities-in-ember-cli-stripe)

- Bump `@xmldom/xmldom` override range from `<0.8.12 → ^0.8.12` to `<0.8.13 → ^0.8.13` — clears 4 high-severity advisories (GHSA-2v35-w6hq-6mfw, GHSA-f6ww-3ggp-fr8h, GHSA-x6wf-f3px-wcqx, GHSA-j759-j44w-7fr8).
- Add `uuid@<14.0.0 → ^14.0.0` override — clears moderate advisory GHSA-w5hq-g745-h8pq (missing buffer bounds check).
- All affected packages are transitive test-only dependencies via `test-app > ember-cli > testem`; the shipped addon is not affected.

After: `smile-cli run pnpm audit` → **No known vulnerabilities found**.



🤖 Generated with [Claude Code](https://claude.com/claude-code)