### PR TITLE
ci: fix failing workflows (pin actions to SHAs, version-less minimatch patch)

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           ref: 'main'
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
           node-version: 18
           cache: pnpm
@@ -77,7 +77,7 @@ jobs:
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           commit-message: "Prepare Release using 'release-plan'"
           labels: "internal"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
           node-version: 18
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable

--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -29,7 +29,7 @@ jobs:
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
-      - uses: kategengler/put-built-npm-package-contents-on-branch@v2.0.0
+      - uses: kategengler/put-built-npm-package-contents-on-branch@5b33924ea713bcde29273ef55bac7e4142a7b917 # v2.0.0
         with:
           branch: dist
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": "^7.29.4"
     },
     "patchedDependencies": {
-      "minimatch@10.2.4": "patches/minimatch@10.2.4.patch"
+      "minimatch": "patches/minimatch@10.2.4.patch"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ overrides:
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': ^7.29.4
 
 patchedDependencies:
-  minimatch@10.2.4:
+  minimatch:
     hash: 3bda299b7a9c08eb9a8751d2d8b05776d7d0b273021fe9e17e522f1e6cdbb9f9
     path: patches/minimatch@10.2.4.patch
 


### PR DESCRIPTION
**Ticket:** ACT-1876

## Description

Two unrelated-but-adjacent failures were keeping ember-cli-stripe's CI red. This PR fixes both.

### 1. Pin all GitHub Actions to commit SHAs

The org policy requires every GitHub Action to be pinned to a full-length commit SHA. An earlier pinning pass (`1642932`) missed a few actions, so the workflows that run on push to `main` had been failing at the *prepare-actions* step:

| Workflow | Unpinned action(s) |
|---|---|
| `push-dist.yml` | `kategengler/put-built-npm-package-contents-on-branch@v2.0.0` |
| `plan-release.yml` | `actions/setup-node@v4`, `peter-evans/create-pull-request@v7` |
| `publish.yml` | `actions/setup-node@v4` (latent - release-gated job) |

All pinned to commit SHAs matching the versions they replaced (`setup-node 1d0ff46 # v4`, `kategengler 5b33924 # v2.0.0`, `create-pull-request 22a9089 # v7`). No behaviour change.

**Why it matters:** `push-dist.yml` publishes the compiled addon to the `dist` branch, which downstream consumers (smile-admin) install via a git SHA. Because "Push dist" has failed on every run since the policy landed, `dist` is stale - last published from `e10e90f7` (Apr 7), missing the default-export fixes merged in #239. Merging this lets "Push dist" run again and republish `dist` from current `main`, unblocking the smile-admin side of ACT-1876 (removing the `fixAppShimReexports` Vite workaround).

### 2. Apply the minimatch patch by name so floating installs pass

The `Floating Dependencies` CI job (and `ember-beta`/`canary`/`release`) failed with `ERR_PNPM_PATCH_NOT_APPLIED: minimatch@10.2.4`. The minimatch patch is a CJS back-compat shim (restores callable `require('minimatch')`, needed because the security override forces minimatch 10.x). It was keyed to the exact version `10.2.4`, but the floating job installs with `--no-lockfile`, which re-resolves minimatch to the latest in range (now `10.2.5`) - so there was no `10.2.4` to patch.

Fix: drop the version from the `patchedDependencies` key (`minimatch@10.2.4` → `minimatch`) so the patch applies to whatever `10.2.x` resolves. Lockfile regenerated to match.

## How has this been tested?

- Verified every action in the active root workflows is now pinned to a 40-char SHA.
- Reproduced the failing floating install locally: `pnpm install --no-lockfile` now exits 0 and the CJS shim is present in the installed minimatch.
- Confirmed the patch's anchor context (`exports.minimatch.unescape = ...`) is unchanged in minimatch `10.2.5`, so the patch applies cleanly there too.
- The actual dist republish runs on merge (`push-dist` triggers on push to `main`); I'll confirm the `dist` branch updates and carries the default exports before re-pinning smile-admin.

## Notes

`test-app/.github/workflows/ci.yml` also has unpinned actions but is intentionally left alone - it lives in a nested `.github/` directory, so GitHub never executes it and the policy doesn't apply.
