### PR TITLE
Migrate `inject` to `service` from @ember/service

### DIFF
--- a/ember-cli-stripe/src/components/stripe-checkout.gjs
+++ b/ember-cli-stripe/src/components/stripe-checkout.gjs
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { on } from '@ember/modifier';
 import {
   configurationOptions,


### PR DESCRIPTION
## Summary
- Replace `import { inject as service }` with `import { service }` in `stripe-checkout.gjs`. The legacy `inject` export from `@ember/service` is removed/throwing under ember-source 7, so consumers on Ember 7 need the direct `service` import.
- `service` is available since Ember 4.1 and this addon's `ember-source` peer is `>= 4.12.0`, so no consumer regresses.

## Context
Part of [ACT-1953](https://linear.app/smile/issue/ACT-1953) — removing the ember-source 7 compatibility patches in `smile-admin`. `ember-cli-stripe` is one of the addons the `patches/ember-source@7.0.0.patch` workaround was covering. This is the only source file in the addon still importing the deprecated `inject`.

## Test plan
- [x] `pnpm --filter ember-cli-stripe build` passes
- [x] `pnpm --filter ember-cli-stripe lint` passes
- [ ] On merge, the `push-dist` workflow republishes the `dist` branch; `smile-admin` then repins to the new `dist` SHA