### PR TITLE
Bump release-plan to fix changelog ESM crash in release prep

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: "Generate Explanation and Prep Changelogs"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
-          node-version: 18
+          node-version: 20
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "concurrently": "^8.2.0",
     "prettier": "^3.0.3",
     "prettier-plugin-ember-template-tag": "^2.0.2",
-    "release-plan": "^0.16.0"
+    "release-plan": "^0.18.0"
   },
   "packageManager": "pnpm@10.2.1",
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.6(prettier@3.5.3)
       release-plan:
-        specifier: ^0.16.0
-        version: 0.16.0
+        specifier: ^0.18.0
+        version: 0.18.0
 
   ember-cli-stripe:
     dependencies:
@@ -4033,8 +4033,8 @@ packages:
     resolution: {integrity: sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==}
     engines: {node: '>= 4.0'}
 
-  github-changelog@2.0.0:
-    resolution: {integrity: sha512-JdAwddNCvHkZY/pTMqpoaLEfksaWiTc+beDjBkPEnr7iVlKfu8SeyCT8Sef+KsonRgIj6pl3SiWDPSefWmeicw==}
+  github-changelog@2.1.4:
+    resolution: {integrity: sha512-mZQF/YC9OR8XMGpYlLQqG66RiKwlaQZ7rXTZug28oOYkzOXd0acszuvYHVzPlYmns1aDDSwQkbzFxNOYpWhmig==}
     engines: {node: 18.* || 20.* || >= 22}
     hasBin: true
 
@@ -5710,8 +5710,8 @@ packages:
     resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
     hasBin: true
 
-  release-plan@0.16.0:
-    resolution: {integrity: sha512-S2hrXACiy39LenrdvPAhSY7PcitS4A4fAxlzoPgYyCiS2OU6Ed+cUKvN4h9/uRyZ/B3AMGywZUIPtIhCUIjTng==}
+  release-plan@0.18.0:
+    resolution: {integrity: sha512-WzP+O+XRF4AqhTDQK84FovY+TxHyC8J7QWoOwxnrvVjyHns417l1FUldboRhBYua5Pej6Yg/2jH1dEH2MRNHeA==}
     hasBin: true
 
   remote-git-tags@3.0.0:
@@ -11861,7 +11861,7 @@ snapshots:
 
   git-repo-info@2.1.1: {}
 
-  github-changelog@2.0.0:
+  github-changelog@2.1.4:
     dependencies:
       '@manypkg/get-packages': 2.2.2
       chalk: 4.1.2
@@ -13588,7 +13588,7 @@ snapshots:
     dependencies:
       jsesc: 3.0.2
 
-  release-plan@0.16.0:
+  release-plan@0.18.0:
     dependencies:
       '@manypkg/get-packages': 2.2.2
       '@npmcli/package-json': 6.2.0
@@ -13598,7 +13598,7 @@ snapshots:
       cli-highlight: 2.1.11
       execa: 9.6.0
       fs-extra: 11.3.0
-      github-changelog: 2.0.0
+      github-changelog: 2.1.4
       js-yaml: 4.3.0
       latest-version: 9.0.0
       parse-github-repo-url: 1.4.1


### PR DESCRIPTION
**LINEAR Ticket:** N/A

# Description

Bumps `release-plan` from `^0.16.0` to `^0.18.0` to fix the `ERR_REQUIRE_ESM` crash in the automated "Prepare Release" PR ([ref](https://github.com/smile-io/ember-cli-stripe/pull/206)). The old version pulled `github-changelog@2.0.0`, which `require()`d the ESM-only `@tootallnate/once`, breaking changelog generation. The new version resolves `github-changelog@2.1.4` and no longer hits that chain.

# How has this been tested?

## Manual testing

- Ran `release-plan prepare` locally; the `ERR_REQUIRE_ESM` error is gone. It now reaches the changelog fetch and only fails on `Must provide GITHUB_AUTH`, which is expected locally and satisfied by the token in CI.

## Automated testing

- N/A

# Deployment dependencies

- N/A
