### PR TITLE
fix(deps): resolve 4 Dependabot security alerts via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "socket.io-parser@>=4.0.0 <4.2.6": "^4.2.6",
       "picomatch@<2.3.2": "^2.3.2",
       "picomatch@>=4.0.0 <4.0.4": "^4.0.4",
-      "brace-expansion@<5.0.5": "^5.0.6",
+      "brace-expansion@<5.0.7": "^5.0.7",
       "handlebars@>=4.0.0 <4.7.9": "^4.7.9",
       "path-to-regexp@<0.1.13": "^0.1.13",
       "path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0",
@@ -75,7 +75,9 @@
       "tar@<=7.5.15": "^7.5.16",
       "js-yaml@<3.15.0": "^3.15.0",
       "js-yaml@>=4.0.0 <=4.1.1": "^4.2.0",
-      "morgan@>=1.2.0 <=1.10.1": "^1.11.0"
+      "morgan@>=1.2.0 <=1.10.1": "^1.11.0",
+      "websocket-driver@<0.7.5": "^0.7.5",
+      "engine.io@>=4.1.0 <6.6.7": "^6.6.7"
     },
     "patchedDependencies": {
       "minimatch": "patches/minimatch@10.2.4.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   socket.io-parser@>=4.0.0 <4.2.6: ^4.2.6
   picomatch@<2.3.2: ^2.3.2
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
-  brace-expansion@<5.0.5: ^5.0.6
+  brace-expansion@<5.0.7: ^5.0.7
   handlebars@>=4.0.0 <4.7.9: ^4.7.9
   path-to-regexp@<0.1.13: ^0.1.13
   path-to-regexp@>=8.0.0 <8.4.0: ^8.4.0
@@ -52,6 +52,8 @@ overrides:
   js-yaml@<3.15.0: ^3.15.0
   js-yaml@>=4.0.0 <=4.1.1: ^4.2.0
   morgan@>=1.2.0 <=1.10.1: ^1.11.0
+  websocket-driver@<0.7.5: ^0.7.5
+  engine.io@>=4.1.0 <6.6.7: ^6.6.7
 
 patchedDependencies:
   minimatch:
@@ -1878,6 +1880,9 @@ packages:
   '@types/symlink-or-copy@1.2.2':
     resolution: {integrity: sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/project-service@8.34.0':
     resolution: {integrity: sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2331,9 +2336,9 @@ packages:
   body@5.1.0:
     resolution: {integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3422,8 +3427,8 @@ packages:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
 
-  engine.io@6.6.4:
-    resolution: {integrity: sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==}
+  engine.io@6.6.9:
+    resolution: {integrity: sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==}
     engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.18.1:
@@ -6682,8 +6687,8 @@ packages:
       webpack-cli:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -8841,6 +8846,10 @@ snapshots:
 
   '@types/symlink-or-copy@1.2.2': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.15.30
+
   '@typescript-eslint/project-service@8.34.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@5.8.3)
@@ -9388,7 +9397,7 @@ snapshots:
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11002,15 +11011,16 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.4:
+  engine.io@6.6.9:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 22.15.30
+      '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.5
-      debug: 4.3.7
+      debug: 4.4.1
       engine.io-parser: 5.2.3
       ws: 8.21.0
     transitivePeerDependencies:
@@ -11499,7 +11509,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-watchman@2.0.2:
     dependencies:
@@ -12886,7 +12896,7 @@ snapshots:
 
   minimatch@10.2.4(patch_hash=3bda299b7a9c08eb9a8751d2d8b05776d7d0b273021fe9e17e522f1e6cdbb9f9):
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -14037,7 +14047,7 @@ snapshots:
       base64id: 2.0.0
       cors: 2.8.5
       debug: 4.3.7
-      engine.io: 6.6.4
+      engine.io: 6.6.9
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.6
     transitivePeerDependencies:
@@ -14825,7 +14835,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
**Ticket:** [ACT-2036](https://linear.app/smile/issue/ACT-2036)

## What this does

Fixes the open [Dependabot alerts](https://github.com/smile-io/ember-cli-stripe/security/dependabot) on ember-cli-stripe - 4 alerts across 3 packages (1 critical, 2 high, 1 medium). All are transitive devDependencies, so nothing here reaches a published bundle.

The fix raises override floors in `package.json` `pnpm.overrides` (pnpm 10 reads them there). Keys are range-scoped so only the vulnerable copies move.

| Package | Resolved to | Severity | Advisories |
|---------|-------------|----------|-----------|
| websocket-driver | 0.7.5 | Critical / Medium | CVE-2026-54466, CVE-2026-54490 |
| engine.io | 6.6.9 | High | CVE-2026-59725 (connection exhaustion) |
| brace-expansion | 5.0.8 | High | CVE-2026-13149 (exponential-time expansion DoS) |

## How it was tested

- Verified against a fresh checkout of `origin/main`, so the version spread matches what Dependabot sees.
- Confirmed every vulnerable version is gone from `pnpm-lock.yaml` and replaced by the patched one.
- Ran the addon build (`pnpm build`, rollup). It builds.
- CI runs the full lint and test suite.

## Rollback

Revert this PR. The previous override floors resolve back to the prior versions. No consumer action needed since these are devDependencies.
